### PR TITLE
Add a setting for the view to be shown at start

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -177,6 +177,12 @@
             android:exported="false"
             />
         <activity
+            android:name=".feature.tabs.settings.view.ChooseDefaultViewActivity"
+            android:screenOrientation="fullSensor"
+            android:configChanges="orientation|screenSize"
+            android:exported="false"
+            />
+        <activity
             android:name=".feature.tabs.settings.camera.ChooseCameraActivity"
             android:screenOrientation="fullSensor"
             android:configChanges="orientation|screenSize"

--- a/app/src/main/java/com/example/barcodescanner/feature/tabs/BottomTabsActivity.kt
+++ b/app/src/main/java/com/example/barcodescanner/feature/tabs/BottomTabsActivity.kt
@@ -5,20 +5,24 @@ import android.view.MenuItem
 import androidx.fragment.app.Fragment
 import com.example.barcodescanner.BuildConfig
 import com.example.barcodescanner.R
+import com.example.barcodescanner.di.settings
 import com.example.barcodescanner.extension.applySystemWindowInsets
 import com.example.barcodescanner.feature.BaseActivity
 import com.example.barcodescanner.feature.tabs.create.CreateBarcodeFragment
 import com.example.barcodescanner.feature.tabs.history.BarcodeHistoryFragment
 import com.example.barcodescanner.feature.tabs.scan.ScanBarcodeFromCameraFragment
 import com.example.barcodescanner.feature.tabs.settings.SettingsFragment
+import com.example.barcodescanner.model.DefaultView
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import kotlinx.android.synthetic.main.activity_bottom_tabs.*
 
 class BottomTabsActivity : BaseActivity(), BottomNavigationView.OnNavigationItemSelectedListener {
 
     companion object {
+        private const val ACTION_SCAN = "${BuildConfig.APPLICATION_ID}.SCAN"
         private const val ACTION_CREATE_BARCODE = "${BuildConfig.APPLICATION_ID}.CREATE_BARCODE"
         private const val ACTION_HISTORY = "${BuildConfig.APPLICATION_ID}.HISTORY"
+        private const val ACTION_SETTINGS = "${BuildConfig.APPLICATION_ID}.SETTINGS"
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -42,10 +46,10 @@ class BottomTabsActivity : BaseActivity(), BottomNavigationView.OnNavigationItem
     }
 
     override fun onBackPressed() {
-        if (bottom_navigation_view.selectedItemId == R.id.item_scan) {
+        if (bottom_navigation_view.selectedItemId == getDefaultViewID()) {
             super.onBackPressed()
         } else {
-            bottom_navigation_view.selectedItemId = R.id.item_scan
+            bottom_navigation_view.selectedItemId = getDefaultViewID()
         }
     }
 
@@ -57,13 +61,25 @@ class BottomTabsActivity : BaseActivity(), BottomNavigationView.OnNavigationItem
         bottom_navigation_view.apply {
             setOnNavigationItemSelectedListener(this@BottomTabsActivity)
         }
+        bottom_navigation_view.selectedItemId = getDefaultViewID()
     }
 
     private fun showInitialFragment() {
         when (intent?.action) {
+            ACTION_SCAN -> bottom_navigation_view.selectedItemId = R.id.item_scan
             ACTION_CREATE_BARCODE -> bottom_navigation_view.selectedItemId = R.id.item_create
             ACTION_HISTORY -> bottom_navigation_view.selectedItemId = R.id.item_history
-            else -> showFragment(R.id.item_scan)
+            ACTION_SETTINGS -> bottom_navigation_view.selectedItemId = R.id.item_settings
+            else -> showFragment(getDefaultViewID())
+        }
+    }
+
+    private fun getDefaultViewID() : Int {
+        return when (settings.defaultView) {
+            DefaultView.CREATE -> R.id.item_create
+            DefaultView.HISTORY -> R.id.item_history
+            DefaultView.SETTINGS -> R.id.item_settings
+            else -> R.id.item_scan
         }
     }
 

--- a/app/src/main/java/com/example/barcodescanner/feature/tabs/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/example/barcodescanner/feature/tabs/settings/SettingsFragment.kt
@@ -20,6 +20,7 @@ import com.example.barcodescanner.feature.tabs.settings.formats.SupportedFormats
 import com.example.barcodescanner.feature.tabs.settings.permissions.AllPermissionsActivity
 import com.example.barcodescanner.feature.tabs.settings.search.ChooseSearchEngineActivity
 import com.example.barcodescanner.feature.tabs.settings.theme.ChooseThemeActivity
+import com.example.barcodescanner.feature.tabs.settings.view.ChooseDefaultViewActivity
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.rxkotlin.addTo
@@ -77,6 +78,7 @@ class SettingsFragment : Fragment(), DeleteConfirmationDialogFragment.Listener {
 
     private fun handleButtonClicks() {
         button_choose_theme.setOnClickListener { ChooseThemeActivity.start(requireActivity()) }
+        button_choose_default_view.setOnClickListener{ChooseDefaultViewActivity.start(requireActivity()) }
         button_choose_camera.setOnClickListener { ChooseCameraActivity.start(requireActivity()) }
         button_select_supported_formats.setOnClickListener { SupportedFormatsActivity.start(requireActivity()) }
         button_clear_history.setOnClickListener { showDeleteHistoryConfirmationDialog() }

--- a/app/src/main/java/com/example/barcodescanner/feature/tabs/settings/view/ChooseDefaultViewActivity.kt
+++ b/app/src/main/java/com/example/barcodescanner/feature/tabs/settings/view/ChooseDefaultViewActivity.kt
@@ -1,0 +1,103 @@
+package com.example.barcodescanner.feature.tabs.settings.view
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.view.View
+import com.example.barcodescanner.R
+import com.example.barcodescanner.di.settings
+import com.example.barcodescanner.extension.applySystemWindowInsets
+import com.example.barcodescanner.extension.unsafeLazy
+import com.example.barcodescanner.feature.BaseActivity
+import com.example.barcodescanner.model.DefaultView
+import com.example.barcodescanner.usecase.Settings
+import kotlinx.android.synthetic.main.activity_choose_default_view.*
+
+class ChooseDefaultViewActivity : BaseActivity() {
+
+    companion object {
+        fun start(context: Context) {
+            val intent = Intent(context, ChooseDefaultViewActivity::class.java)
+            context.startActivity(intent)
+        }
+    }
+
+    private val buttons by unsafeLazy {
+        listOf(button_scan_view, button_create_view, button_history_view, button_settings_view)
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_choose_default_view)
+        supportEdgeToEdge()
+        initToolbar()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        showInitialSettings()
+        handleSettingsChanged()
+    }
+
+    private fun supportEdgeToEdge() {
+        root_view.applySystemWindowInsets(applyTop = true, applyBottom = true)
+    }
+
+    private fun initToolbar() {
+        toolbar.setNavigationOnClickListener { finish() }
+    }
+
+    private fun showInitialSettings() {
+        val view = settings.defaultView
+        button_scan_view.isChecked = view == DefaultView.SCAN
+        button_create_view.isChecked = view == DefaultView.CREATE
+        button_history_view.isChecked = view == DefaultView.HISTORY
+        button_settings_view.isChecked = view == DefaultView.SETTINGS
+    }
+
+    private fun handleSettingsChanged() {
+        button_scan_view.setCheckedChangedListener { isChecked ->
+            if (isChecked.not()) {
+                return@setCheckedChangedListener
+            }
+
+            uncheckOtherButtons(button_scan_view)
+            settings.defaultView = DefaultView.SCAN
+        }
+
+        button_create_view.setCheckedChangedListener { isChecked ->
+            if (isChecked.not()) {
+                return@setCheckedChangedListener
+            }
+
+            uncheckOtherButtons(button_create_view)
+            settings.defaultView = DefaultView.CREATE
+        }
+
+        button_history_view.setCheckedChangedListener { isChecked ->
+            if (isChecked.not()) {
+                return@setCheckedChangedListener
+            }
+
+            uncheckOtherButtons(button_history_view)
+            settings.defaultView = DefaultView.HISTORY
+        }
+
+        button_settings_view.setCheckedChangedListener { isChecked ->
+            if (isChecked.not()) {
+                return@setCheckedChangedListener
+            }
+
+            uncheckOtherButtons(button_settings_view)
+            settings.defaultView = DefaultView.SETTINGS
+        }
+    }
+
+    private fun uncheckOtherButtons(checkedButton: View) {
+        buttons.forEach { button ->
+            if (checkedButton !== button) {
+                button.isChecked = false
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/barcodescanner/model/DefaultView.kt
+++ b/app/src/main/java/com/example/barcodescanner/model/DefaultView.kt
@@ -1,0 +1,8 @@
+package com.example.barcodescanner.model
+
+enum class DefaultView() {
+    SCAN,
+    CREATE,
+    HISTORY,
+    SETTINGS
+}

--- a/app/src/main/java/com/example/barcodescanner/usecase/Settings.kt
+++ b/app/src/main/java/com/example/barcodescanner/usecase/Settings.kt
@@ -7,6 +7,7 @@ import android.os.Build
 import androidx.appcompat.app.AppCompatDelegate
 import com.example.barcodescanner.BuildConfig
 import com.example.barcodescanner.extension.unsafeLazy
+import com.example.barcodescanner.model.DefaultView
 import com.example.barcodescanner.model.SearchEngine
 import com.google.zxing.BarcodeFormat
 
@@ -28,6 +29,7 @@ class Settings(private val context: Context) {
     private enum class Key {
         THEME,
         INVERSE_BARCODE_COLORS,
+        DEFAULT_VIEW,
         OPEN_LINKS_AUTOMATICALLY,
         COPY_TO_CLIPBOARD,
         SIMPLE_AUTO_FOCUS,
@@ -53,6 +55,10 @@ class Settings(private val context: Context) {
             set(Key.THEME, value)
             applyTheme(value)
         }
+
+    var defaultView: DefaultView
+        get() = get(Key.DEFAULT_VIEW, DefaultView.SCAN)
+        set(value) = set(Key.DEFAULT_VIEW, value)
 
     val isDarkTheme: Boolean
         get() = theme == THEME_DARK || (theme == THEME_SYSTEM && isSystemDarkModeEnabled())
@@ -160,6 +166,17 @@ class Settings(private val context: Context) {
         sharedPreferences.edit()
             .putBoolean(key.name, value)
             .apply()
+    }
+
+    private fun get(key: Key, default: DefaultView = DefaultView.SCAN) : DefaultView {
+        val rawValue = sharedPreferences.getString(key.name, null) ?: default.name
+        return DefaultView.valueOf(rawValue);
+    }
+
+    private fun set(key: Key, value: DefaultView) {
+        sharedPreferences.edit()
+                .putString(key.name, value.name)
+                .apply()
     }
 
     private fun get(key: Key, default: SearchEngine = SearchEngine.NONE): SearchEngine {

--- a/app/src/main/res/layout/activity_choose_default_view.xml
+++ b/app/src/main/res/layout/activity_choose_default_view.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout
+    android:id="@+id/root_view"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    >
+
+    <com.google.android.material.appbar.AppBarLayout
+        style="@style/AppBarLayoutStyle"
+        >
+        <androidx.appcompat.widget.Toolbar
+            android:id="@+id/toolbar"
+            app:title="@string/activity_choose_default_view_title"
+            style="@style/ToolbarWithBackButtonStyle"
+            />
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <androidx.core.widget.NestedScrollView
+        android:id="@+id/scroll_view"
+        style="@style/ScrollStyle"
+        >
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:orientation="vertical"
+            >
+
+            <com.example.barcodescanner.feature.common.view.SettingsRadioButton
+                android:id="@+id/button_scan_view"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:layout_constraintTop_toBottomOf="@id/toolbar"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:text="@string/activity_choose_default_view_scan"
+                />
+            <com.example.barcodescanner.feature.common.view.SettingsRadioButton
+                android:id="@+id/button_create_view"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:layout_constraintTop_toBottomOf="@id/button_scan_view"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:text="@string/activity_choose_default_view_create"
+                />
+            <com.example.barcodescanner.feature.common.view.SettingsRadioButton
+                android:id="@+id/button_history_view"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:layout_constraintTop_toBottomOf="@id/button_create_view"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:text="@string/activity_choose_default_view_history"
+                />
+            <com.example.barcodescanner.feature.common.view.SettingsRadioButton
+                android:id="@+id/button_settings_view"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:layout_constraintTop_toBottomOf="@id/button_history_view"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:text="@string/activity_choose_default_view_settings"
+                />
+        </LinearLayout>
+    </androidx.core.widget.NestedScrollView>
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -52,6 +52,15 @@
                 app:text="@string/fragment_settings_inverse_barcode_colors_in_dark_theme"
                 app:hint="@string/fragment_settings_inverse_barcode_colors_in_dark_theme_hint"
                 />
+
+            <com.example.barcodescanner.feature.common.view.SettingsButton
+                android:id="@+id/button_choose_default_view"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:text="@string/fragment_settings_choose_default_view"
+                app:hint="@string/fragment_settings_choose_default_view_hint"
+                app:isSwitchVisible="false"
+                />
             <View
                 android:id="@+id/delimiter_appearance"
                 style="@style/DelimiterStyle"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -201,6 +201,8 @@
     <!--Settings fragment-->
     <string name="fragment_settings_title">Settings</string>
     <string name="fragment_settings_appearance_settings">Appearance</string>
+    <string name="fragment_settings_choose_default_view">Default view</string>
+    <string name="fragment_settings_choose_default_view_hint">Choose the view which is opened at start</string>
     <string name="fragment_settings_theme">Theme</string>
     <string name="fragment_settings_inverse_barcode_colors_in_dark_theme">Inverse code colors in dark theme</string>
     <string name="fragment_settings_inverse_barcode_colors_in_dark_theme_hint">Show codes with white content on dark background</string>
@@ -244,6 +246,13 @@
     <string name="activity_choose_theme_system">Same as system</string>
     <string name="activity_choose_theme_light">Light</string>
     <string name="activity_choose_theme_dark">Dark</string>
+
+    <!--Choose default view activity-->
+    <string name="activity_choose_default_view_title">Default view</string>
+    <string name="activity_choose_default_view_scan">Scan</string>
+    <string name="activity_choose_default_view_create">Create</string>
+    <string name="activity_choose_default_view_history">History</string>
+    <string name="activity_choose_default_view_settings">Settings</string>
 
     <!--Choose camera activity-->
     <string name="activity_choose_camera_title">Camera</string>


### PR DESCRIPTION
## Problem
My camera is a bit slow and i have to wait for a few seconds every time i start the app.

## Solution
As the title says, i'd like this app to have the option to select the start view.
I don't always want to scan something, so it would be more efficient for me to start the app on the history or the create fragment.

## Pull request
I have implemented this functionality on my branch and will submit it shortly.

(I don't have much experience with commits and pull requests so please be nice and feel free to correct me on my errors ^^ )